### PR TITLE
update documentation about target attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For each node you will have access to:
 	{{ node.name }}
 	{{ node.url }}
 	{{ node.classes }}
-	{{ node.target }}
+	{{ node.blank }}
 	{{ node.children }}
 {% endfor %} 
 ```


### PR DESCRIPTION
Documentation was not right about target attribute, while in the example which says that I'll access to node.target which is wrong and in the small macro it's right.