### PR TITLE
Added current() test to NodeModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.8.1 - 2021-09-28
+### Fixed
+- Fixed an issue where the sites for which a nav was enabled wasn't checked against the sites a user could edit
+- Fixed an issue where active state checking would only on PHP 8 or higher
+
 ## 2.8.0 - 2021-07-18
 ### Added
 - The Node classes field now be filled with predefined values, more information can be found in the [readme](https://github.com/studioespresso/craft3-navigate/tree/master#css-class-option-list) ([#57](https://github.com/studioespresso/craft3-navigate/issues/57)).

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "studioespresso/craft-navigate",
     "description": "Navigation plugin for Craft 3",
     "type": "craft-plugin",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -179,7 +179,7 @@ class DefaultController extends Controller
             });
         } elseif(count($enabledForSites)) {
             if($currentUser->can('accessPlugin-navigate')) {
-                $editableSites = Craft::$app->getSites()->getAllSites();
+                $editableSites = $enabledForSites;
             }
         } else {
             if($currentUser->can('accessPlugin-navigate')) {

--- a/src/models/NodeModel.php
+++ b/src/models/NodeModel.php
@@ -147,4 +147,31 @@ class NodeModel extends Model
         }
         return false;
     }
+
+    public function current()
+    {
+        switch ($this->type) {
+            case 'url':
+                if (substr(Craft::$app->request->getPathInfo(), 0, strlen($this->url)) === $this->url) {
+                    return true;
+                }
+                if (substr("/". Craft::$app->request->getPathInfo(), 0, strlen($this->url)) === $this->url) {
+                    return true;
+                }
+
+                break;
+            default:
+                if ($this->url === Craft::$app->request->getAbsoluteUrl()) {
+                    return true;
+                }
+                
+                if(strpos(Craft::$app->request->getAbsoluteUrl(), '?')) {
+                    if(explode('?', Craft::$app->request->getAbsoluteUrl())[0] === $this->url) {
+                        return true;
+                    }
+                }
+                break;
+        }
+        return false;
+    }    
 }

--- a/src/models/NodeModel.php
+++ b/src/models/NodeModel.php
@@ -134,7 +134,8 @@ class NodeModel extends Model
                 if ($this->url === Craft::$app->request->getAbsoluteUrl()) {
                     return true;
                 }
-                if(str_contains(Craft::$app->request->getAbsoluteUrl(), '?')) {
+                
+                if(strpos(Craft::$app->request->getAbsoluteUrl(), '?')) {
                     if(explode('?', Craft::$app->request->getAbsoluteUrl())[0] === $this->url) {
                         return true;
                     }


### PR DESCRIPTION
Adds a function to NodeModel called current() which lets you to test whether a node URL matches the current page URL exactly.

This is different from the existing active() function which will return true if one of the nodes children is active.