### PR TITLE
Possible fix for active state of Node

### DIFF
--- a/src/models/NodeModel.php
+++ b/src/models/NodeModel.php
@@ -142,7 +142,7 @@ class NodeModel extends Model
                         return true;
                     }
                 }
-                if (substr(Craft::$app->request->getPathInfo(), 0, strlen($this->slug . "/")) === $this->slug . "/") {
+                if (substr(Craft::$app->request->getPathInfo() . "/", 0, strlen($this->slug . "/")) === $this->slug . "/") {
                     return true;
                 }
                 break;


### PR DESCRIPTION
Hi Jan

I noticed something odd when using pagination and the active state of a node.

The situation: 
I go to the following URL: https://www.example.be/articles and the Node in the navigation linked to this entry becomes active and I can add some classes to it. 
When I use pagination and go to the next page the URL becomes https://www.example.be/articles/p2 and the Node in the navigation linked to this entry loses its active state. 

I then looked in the code and tried a possible fix. 

Can you check it out and let me know what you think about it?

Greetings
Robin
